### PR TITLE
Catch errors from BlangParser

### DIFF
--- a/EternalModLoader/EternalModLoader.cs
+++ b/EternalModLoader/EternalModLoader.cs
@@ -340,7 +340,7 @@ namespace EternalModLoader
                                 Console.ForegroundColor = ConsoleColor.Red;
                                 Console.Write("ERROR: ");
                                 Console.ResetColor();
-                                Console.WriteLine($"Failed to parse {resourceInfo.Name}/{mod.Name} - are you trying to inject to the wrong .resources?");
+                                Console.WriteLine($"Failed to parse {resourceInfo.Name}/{mod.Name} - are you trying to change strings in the wrong .resources archive?");
                                 continue;
                             }
                             

--- a/EternalModLoader/EternalModLoader.cs
+++ b/EternalModLoader/EternalModLoader.cs
@@ -321,13 +321,29 @@ namespace EternalModLoader
 
                         if (res != 0)
                         {
+                            Console.ForegroundColor = ConsoleColor.Red;
+                            Console.Write("ERROR: ");
+                            Console.ResetColor();
+                            Console.WriteLine($"Failed to parse {resourceInfo.Name}/{mod.Name}");
                             continue;
                         }
 
                         BlangFile blangFile;
                         using (var blangMemoryStream = new MemoryStream(blangFileBytes))
                         {
-                            blangFile = BlangFile.ParseFromMemory(blangMemoryStream);
+                            try
+                            {
+                                blangFile = BlangFile.ParseFromMemory(blangMemoryStream);
+                            }
+                            catch
+                            {
+                                Console.ForegroundColor = ConsoleColor.Red;
+                                Console.Write("ERROR: ");
+                                Console.ResetColor();
+                                Console.WriteLine($"Failed to parse {resourceInfo.Name}/{mod.Name} - are you trying to inject to the wrong .resources?");
+                                continue;
+                            }
+                            
                         }
 
                         foreach (var blangJsonString in blangJson.Strings)
@@ -364,6 +380,10 @@ namespace EternalModLoader
 
                         if (res != 0)
                         {
+                            Console.ForegroundColor = ConsoleColor.Red;
+                            Console.Write("ERROR: ");
+                            Console.ResetColor();
+                            Console.WriteLine($"Failed to parse {resourceInfo.Name}/{mod.Name}");
                             continue;
                         }
 


### PR DESCRIPTION
Adds a try-catch statement to BlangParser call, preventing an exception from it to stop the mod loading process. Should prevent problems if a modder accidentally tries to inject a strings JSON file into `gameresources` or `gameresources_patch2`. Also adds error messages for IdCrypt.