### PR TITLE
Fix extra common map being added to packagemapspec

### DIFF
--- a/EternalModLoader/EternalModLoader.cs
+++ b/EternalModLoader/EternalModLoader.cs
@@ -1421,7 +1421,6 @@ namespace EternalModLoader
                     return;
                 }
 
-
                 if (PackageMapSpecInfo.PackageMapSpec == null && !PackageMapSpecInfo.InvalidPackageMapSpec)
                 {
                     if (!ReadPackageMapSpec())
@@ -2518,10 +2517,16 @@ namespace EternalModLoader
             }
 
             // Get common map index
-            int commonMapIndex = PackageMapSpecInfo.PackageMapSpec.Maps.IndexOf(new PackageMapSpecMap()
+            int commonMapIndex = -1;
+
+            for (int i = 0; i < PackageMapSpecInfo.PackageMapSpec.Maps.Count; i++)
             {
-                Name = "common"
-            });
+                if (PackageMapSpecInfo.PackageMapSpec.Maps[i].Name.Equals("common"))
+                {
+                    commonMapIndex = i;
+                    break;
+                }
+            }
 
             if (commonMapIndex == -1)
             {


### PR DESCRIPTION
Fixes extra `common` map being added to packagemapspec.json when loading a streamdb mod, causing an error message upon loading the game.