### PR TITLE
Don't consider PvP .entities files online-safe

### DIFF
--- a/EternalModLoader/EternalModLoader.cs
+++ b/EternalModLoader/EternalModLoader.cs
@@ -27,7 +27,7 @@ namespace EternalModLoader
         /// <summary>
         /// Mod loader version
         /// </summary>
-        public const int Version = 22;
+        public const int Version = 23;
 
         /// <summary>
         /// Resource data file name

--- a/EternalModLoader/OnlineSafety.cs
+++ b/EternalModLoader/OnlineSafety.cs
@@ -194,12 +194,13 @@ namespace EternalModLoader
             "/tooltip/",
             "/livetile/",
             "/tutorialevent/",
-            "/maps/game/dlc/",
-            "/maps/game/dlc2/",
-            "/maps/game/hub/",
-            "/maps/game/shell/",
-            "/maps/game/sp/",
-            "/maps/game/tutorials/",
+            "maps/game/dlc/",
+            "maps/game/dlc2/",
+            "maps/game/horde/",
+            "maps/game/hub/",
+            "maps/game/shell/",
+            "maps/game/sp/",
+            "maps/game/tutorials/",
             "/decls/campaign/"
         };
 
@@ -277,9 +278,10 @@ namespace EternalModLoader
                     isSafe = false;
                 }
 
-                // Allow modification of anything outside of "generated/decls/"
+                // Allow modification of anything outside of "generated/decls/", except .entities files
                 if (!string.IsNullOrEmpty(resourceModFile.Name)
-                    && !resourceModFile.Name.StartsWith("generated/decls/", StringComparison.OrdinalIgnoreCase))
+                    && !resourceModFile.Name.StartsWith("generated/decls/", StringComparison.OrdinalIgnoreCase)
+                    && !resourceModFile.Name.EndsWith(".entities", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }


### PR DESCRIPTION
Untested. Fixes a false positive with some mods being erroneously considered online-safe, by making *.entities* files go through the same path checks as *generated/decls/\*.decl* files.

The "*/maps/\**" whitelists were changed to "*maps/\**" (without a slash at the start) so that they'll also match (online-safe) .entities files, and "*maps/game/horde/*" was added so that Horde *.entities* files are still considered online-safe.